### PR TITLE
dépendances non nécessaires ?

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
   "repository": "https://github.com/Ybbet/assistant-rappel-calendrier/",
   "license": "MIT",
   "dependencies": {
-    "node-ical": "^0.9.2",
-    "path": "0.12.7",
-    "fs": "^0.0.1-security"
+    "node-ical": "^0.9.2"
   },
   "keywords": [
     "assistant-plugins",


### PR DESCRIPTION
Je me demande pourquoi tu as `path` et `fs` ? Ils sont inclus dans Node déjà, donc pas besoin de les installer, et en plus ton plugin ne les utilise pas à priori ?!